### PR TITLE
Handle expired oauth and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,12 @@ The code was tested in Azure Bot Framework that facilitates to integrate with an
 
 ## Setup and Usage
 
-## Configure your authentication mechanism
+### Configure your authentication mechanism
 1. Go to [`src/const.py`](./src/const.py) and update `AUTH_METHOD` to one of either `oauth` or `service_principal`.
+
+### Configure your Genie Spaces
+1. Please update [spaces.json](./spaces.json) with your own Genie Space IDs in your workspace.
+   1. Retrieve your Space ID from the Genie Space URL - see [docs here](https://learn.microsoft.com/en-us/azure/databricks/genie/conversation-api#-step-3-gather-details)
 
 ### Develop and test locally
 1. Python version 3.12

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ The code was tested in Azure Bot Framework that facilitates to integrate with an
 
 ## Setup and Usage
 
+## Configure your authentication mechanism
+1. Go to [`src/const.py`](./src/const.py) and update `AUTH_METHOD` to one of either `oauth` or `service_principal`.
+
 ### Develop and test locally
 1. Python version 3.12
 2. Install the required dependencies listed in `requirements.txt`
@@ -57,11 +60,23 @@ The code was tested in Azure Bot Framework that facilitates to integrate with an
 
 1. Create App Service Plan
 1. Create Web App on the App Service Plan
+   1. Please use `PYTHON 3.12` when you select the python version
 1. Add Configuration to the web app 
-   1. `gunicorn --bind 0.0.0.0 --worker-class aiohttp.worker.GunicornWebWorker --timeout 1200 --chdir src app:app`
+   1. Set startup command to be:
+
+      ```gunicorn --bind 0.0.0.0 --worker-class aiohttp.worker.GunicornWebWorker --timeout 1200 --chdir src app:app```
+
    1. Set the necessary environment variables for authentication
+      1. Always required:
+         1. `DATABRICKS_HOST` (your Databricks Workspace URL)
+         1. `APP_ID` (your [Azure Bot's App ID](https://docs.azure.cn/en-us/bot-service/bot-builder-authentication?view=azure-bot-service-4.0&tabs=userassigned%2Caadv2%2Ccsharp#to-get-your-app-or-tenant-id))
+         1. `APP_PASSWORD` (your [Azure Bot's Secret](https://docs.azure.cn/en-us/bot-service/bot-builder-authentication?view=azure-bot-service-4.0&tabs=userassigned%2Caadv2%2Ccsharp#to-generate-a-new-password))
+      1. If you want to use [Service Principal Authentication](https://learn.microsoft.com/en-us/azure/databricks/dev-tools/auth/oauth-m2m) (optional otherwise)
+         1. `DATABRICKS_CLIENT_ID`
+         1. `DATABRICKS_CLIENT_SECRET` 
    1. Set environment variable `SCM_DO_BUILD_DURING_DEPLOYMENT` to `true` to ensure the dependencies are installed during deployment.
-1. Create Azure Bot. Add webapp endpoint details to Azure Bot: /api/messages.
+1. Create Azure Bot. Add webapp endpoint details to Azure Bot: `<webapp-url>/api/messages`
+   1. If you're going to use Oauth authentication, please refer to setup instructions [here](./databricks-oauth/readme.md)
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ The code was tested in Azure Bot Framework that facilitates to integrate with an
    1. Set the necessary environment variables for authentication
       1. Always required:
          1. `DATABRICKS_HOST` (your Databricks Workspace URL)
-         1. `APP_ID` (your [Azure Bot's App ID](https://docs.azure.cn/en-us/bot-service/bot-builder-authentication?view=azure-bot-service-4.0&tabs=userassigned%2Caadv2%2Ccsharp#to-get-your-app-or-tenant-id))
-         1. `APP_PASSWORD` (your [Azure Bot's Secret](https://docs.azure.cn/en-us/bot-service/bot-builder-authentication?view=azure-bot-service-4.0&tabs=userassigned%2Caadv2%2Ccsharp#to-generate-a-new-password))
+         1. `APP_ID` (your [Azure Bot's App ID](https://learn.microsoft.com/en-us/azure/bot-service/bot-builder-authentication?view=azure-bot-service-4.0&tabs=userassigned%2Caadv2%2Cpython#to-get-your-app-or-tenant-id))
+         1. `APP_PASSWORD` (your [Azure Bot's Secret](https://learn.microsoft.com/en-us/azure/bot-service/bot-builder-authentication?view=azure-bot-service-4.0&tabs=userassigned%2Caadv2%2Cpython#to-generate-a-new-password))
       1. If you want to use [Service Principal Authentication](https://learn.microsoft.com/en-us/azure/databricks/dev-tools/auth/oauth-m2m) (optional otherwise)
          1. `DATABRICKS_CLIENT_ID`
          1. `DATABRICKS_CLIENT_SECRET` 

--- a/src/app.py
+++ b/src/app.py
@@ -21,7 +21,7 @@ from botbuilder.core import BotFrameworkAdapterSettings, BotFrameworkAdapter, Co
 from botbuilder.schema import Activity, ActivityTypes
 
 from bot import MyBot
-from const import APP_ID, APP_PASSWORD, OAUTH_CONNECTION_NAME
+from const import APP_ID, APP_PASSWORD, OAUTH_CONNECTION_NAME, AUTH_METHOD
 
 from login_dialog import LoginDialog
 
@@ -37,7 +37,7 @@ CONVERSATION_STATE = ConversationState(MEMORY)
 DIALOG = LoginDialog(OAUTH_CONNECTION_NAME)
 
 # Create Bot
-BOT = MyBot(CONVERSATION_STATE, USER_STATE, DIALOG, auth_method="oauth")
+BOT = MyBot(CONVERSATION_STATE, USER_STATE, DIALOG, auth_method=AUTH_METHOD)
 
 SETTINGS = BotFrameworkAdapterSettings(APP_ID, APP_PASSWORD)
 ADAPTER = BotFrameworkAdapter(SETTINGS)

--- a/src/const.py
+++ b/src/const.py
@@ -19,6 +19,7 @@ OAUTH_CONNECTION_NAME = os.getenv("OAUTH_CONNECTION_NAME", "")
 WELCOME_MESSAGE = "Welcome to the Data Query Bot!"
 WAITING_MESSAGE = "Querying Genie for results..."
 SWITCHING_MESSAGE = "switch to @"
+AUTH_METHOD = "oauth" # can also be "service_principal"
 
 # Spaces mapping in json file
 with open("../spaces.json") as f:

--- a/src/login_dialog.py
+++ b/src/login_dialog.py
@@ -51,8 +51,8 @@ class LoginDialog(ComponentDialog):
         # Get the token from the previous step. Note that we could also have gotten the
         # token directly from the prompt itself. There is an example of this in the next method.
         if step_context.result:
-            await step_context.context.send_activity("You are now logged in.")
-            await step_context.context.send_activity("Please proceed to speak with your data.")
+            # await step_context.context.send_activity("You are now logged in.")
+            # await step_context.context.send_activity("Please proceed to speak with your data.")
             return await step_context.end_dialog(step_context.result.token)
 
         await step_context.context.send_activity(

--- a/src/login_dialog.py
+++ b/src/login_dialog.py
@@ -51,8 +51,6 @@ class LoginDialog(ComponentDialog):
         # Get the token from the previous step. Note that we could also have gotten the
         # token directly from the prompt itself. There is an example of this in the next method.
         if step_context.result:
-            # await step_context.context.send_activity("You are now logged in.")
-            # await step_context.context.send_activity("Please proceed to speak with your data.")
             return await step_context.end_dialog(step_context.result.token)
 
         await step_context.context.send_activity(


### PR DESCRIPTION
* Standardized AUTH_METHOD definition in const.py instead of manually defining in app.py
* Added logic to get updated oauth token by using oauth prompt (instead of manually managing expiry datetime)
* Updated readme with more explicit instructions based on beta user feedback